### PR TITLE
Add typings from vega-lite

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+export interface LoggerInterface {
+  level: (_: number) => number | LoggerInterface;
+  warn(...args: any[]): LoggerInterface;
+  info(...args: any[]): LoggerInterface;
+  debug(...args: any[]): LoggerInterface;
+}
+
+export const None: number;
+export const Warn: number;
+export const Info: number;
+export const Debug: number;
+
+export function log(...args: any[]): void;
+export function logger(_: number): LoggerInterface;
+
+export function truncate(a: string, length: number): string;
+
+export function isArray<T>(a: any | T[]): a is T[];
+export function isObject(a: any): a is object;
+export function isString(a: any): a is string;
+export function isNumber(a: any): a is number;
+
+export function toSet<T>(array: T[]): {[T: string]: boolean}
+export function stringValue(a: any): string;
+export function splitAccessPath(path: string): string[];

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "name": "Jeffrey Heer",
     "url": "http://idl.cs.washington.edu"
   },
+  "types": "index.d.ts",
   "main": "build/vega-util.js",
   "module": "index",
   "jsnext:main": "index",


### PR DESCRIPTION
Taken from [here](https://github.com/vega/vega-lite/blob/e9f4753fab9e837be8f46f50506f3285f658b065/typings/vega-util.d.ts). This project should have its own typings, which `vega-lite` (and others) can then depend on.