### PR TITLE
Add typings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+sudo: false
+node_js:
+  - "6"
+  - "8"
+script:
+  - npm run test
+  - npm run tsc

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,120 @@
+// Functions
+
+type AccessorFn = (_: object) => any;
+export function accessor(fn: AccessorFn, fields?: string[], name?: string): AccessorFn;
+export function accessorFields(fn: Function): string[];
+export function accessorName(fn: Function): string;
+
+export function compare(fields: string[], orders?: ('ascending' | 'descending')[]);
+
+export function constant<V>(v: V): () => V;
+
+export function debounce(delay: number, func: Function): Function;
+
+export function field(field: string, name?: string): AccessorFn;
+
+export function id(_: object): symbol;
+
+export function identity<V>(v: V): () => V;
+
+export function key(fields: string[], flat?: boolean): (_: object) => string;
+
+export function one(): 1;
+export function zero(): 0;
+export function truth(): true;
+export function falsy(): false;
+
+// Type Checkers
+export function isArray<T>(a: any | T[]): a is T[];
+export function isBoolean(a: any): a is boolean;
+export function isDate(a: any): a is Date;
+export function isFunction(a: any): a is Function;
+export function isNumber(a: any): a is number;
+export function isObject(a: any): a is object;
+export function isRegExp(a: any): a is RegExp;
+export function isString(a: any): a is string;
+
+// Type Coercion
+export function toBoolean(a: any): boolean;
+export function toDate(a: any, parser?: (_: any) => number): number;
+export function toNumber(a: any): number;
+export function toString(a: any): string;
+
+// Objects
+
+export function extend(target: object, ...source: object[]): object;
+export function inherits(child: object, parent: object): object;
+
+export interface FastMap {
+  size: number;
+  empty: number;
+  has: (f: string) => boolean;
+  get: (f: string) => any;
+  set: (f: string, v: any) => void;
+  delete: (f: string) => void;
+  clean: () => void;
+}
+export function fastmap(_?: object): FastMap;
+
+// Arrays
+
+export function array<T>(v: T): T[];
+
+export function extentIndex(array: number[], accessor?: AccessorFn): number[];
+
+export function merge(compare: (a: any, b: any) => number,
+  array1: any[], array2: any[], output?: any[]): any[];
+
+export function panLinear(domain: number[], delta: number): number[];
+export function panLog(domain: number[], delta: number): number[];
+export function panPow(domain: number[], delta: number, exponent: number): number[];
+
+export function peek(array: any[]): any;
+
+export function toSet<T>(array: T[]): { [T: string]: 1 }
+
+// FIXME: an optional arg before a required one is invalid TypeScript.
+export function visitArray(): void;
+// export function visitArray(array: any[],
+//   filter?: (any) => boolean,
+//   visitor: (v: any, i: number, arr: any[]) => void): void;
+
+export function zoomLinear(domain: number[],
+  anchor: number | null, scale: number): number[];
+
+export function zoomLog(domain: number[],
+  anchor: number | null, scale: number): number[];
+
+export function zoomPow(domain: number[],
+  anchor: number | null, scale: number, exponent: number): number[];
+
+// Strings
+
+export function pad(str: string, len: number,
+  char?: string, align?: 'left' | 'center' | 'right'): string;
+
+export function repeat(str: string, count: number): string;
+
+export function splitAccessPath(path: string): string[];
+export function stringValue(a: any): string;
+
+export function truncate(a: string, length: number,
+  align?: 'left' | 'center' | 'right', ellipsis?: string): string;
+
+// Logging
+
+export interface LoggerInterface {
+  level: (_: number) => number | LoggerInterface;
+  warn(...args: any[]): LoggerInterface;
+  info(...args: any[]): LoggerInterface;
+  debug(...args: any[]): LoggerInterface;
+}
+
+export const None: number;
+export const Warn: number;
+export const Info: number;
+export const Debug: number;
+
+export function logger(_?: number): LoggerInterface;
+export function log(...args: any[]): void;
+export function error(msg: string): Error;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,13 @@ export function accessor(fn: AccessorFn, fields?: string[], name?: string): Acce
 export function accessorFields(fn: Function): string[];
 export function accessorName(fn: Function): string;
 
-export function compare(fields: string[], orders?: ('ascending' | 'descending')[]);
+export type Order = 'ascending' | 'descending';
+
+export function compare(fields: string | string[] | AccessorFn | AccessorFn[], orders?: Order | Order[]): (a: any, b: any) => number;
 
 export function constant<V>(v: V): () => V;
 
-export function debounce(delay: number, func: Function): Function;
+export function debounce<F extends Function>(delay: number, func: F): F;
 
 export function field(field: string, name?: string): AccessorFn;
 
@@ -21,7 +23,7 @@ export function key(fields: string[], flat?: boolean): (_: object) => string;
 
 export function one(): 1;
 export function zero(): 0;
-export function truth(): true;
+export function truthy(): true;
 export function falsy(): false;
 
 // Type Checkers
@@ -58,12 +60,15 @@ export function fastmap(_?: object): FastMap;
 
 // Arrays
 
+export function array<T extends any[]>(v: T): T;
 export function array<T>(v: T): T[];
 
 export function extentIndex(array: number[], accessor?: AccessorFn): number[];
 
 export function merge(compare: (a: any, b: any) => number,
-  array1: any[], array2: any[], output?: any[]): any[];
+  array1: any[], array2: any[]): any[];
+export function merge(compare: (a: any, b: any) => number,
+  array1: any[], array2: any[], output?: any[]): void;
 
 export function panLinear(domain: number[], delta: number): number[];
 export function panLog(domain: number[], delta: number): number[];
@@ -73,11 +78,9 @@ export function peek(array: any[]): any;
 
 export function toSet<T>(array: T[]): { [T: string]: 1 }
 
-// FIXME: an optional arg before a required one is invalid TypeScript.
-export function visitArray(): void;
-// export function visitArray(array: any[],
-//   filter?: (any) => boolean,
-//   visitor: (v: any, i: number, arr: any[]) => void): void;
+export function visitArray(array: any[] | undefined,
+  filter: (any: any) => boolean | undefined,
+  visitor: (v: any, i: number, arr: any[]) => void): void;
 
 export function zoomLinear(domain: number[],
   anchor: number | null, scale: number): number[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ export function panPow(domain: number[], delta: number, exponent: number): numbe
 
 export function peek(array: any[]): any;
 
-export function toSet<T>(array: T[]): { [T: string]: 1 }
+export function toSet<T>(array: T[]): { [T: string]: true }
 
 export function visitArray(array: any[] | undefined,
   filter: (any: any) => boolean | undefined,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "npm run test && uglifyjs build/vega-util.js -c -m -o build/vega-util.min.js",
     "pretest": "rm -rf build && mkdir build && rollup -f umd -n vega -o build/vega-util.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
+    "tsc": "tsc",
     "prepublish": "npm run build",
     "postpublish": "git push && git push --tags && zip -j build/vega-util.zip -- LICENSE README.md build/vega-util.js build/vega-util.min.js"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "build/vega-util.js",
   "module": "index",
   "jsnext:main": "index",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/vega/vega-util.git"
@@ -29,6 +30,7 @@
     "eslint": "2",
     "rollup": "0.43",
     "tape": "4",
+    "typescript": "2",
     "uglify-js": "3"
   }
 }

--- a/src/toSet.js
+++ b/src/toSet.js
@@ -1,4 +1,4 @@
 export default function(_) {
-  for (var s={}, i=0, n=_.length; i<n; ++i) s[_[i]] = 1;
+  for (var s={}, i=0, n=_.length; i<n; ++i) s[_[i]] = true;
   return s;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+    ]
+}


### PR DESCRIPTION
This PR adds complete TypeScript type signatures for vega-util, superseding #7.  

The `visitArray` function caused an issue as the optional `filter` argument comes before the required `visitor`. An optional argument before a required one is invalid TypeScript. We should consider switching the order in the next major release. In the interim, the `visitArray` typings are [very generic](https://github.com/vega/vega-util/pull/8/files#diff-b52768974e6bc0faccb7d4b75b162c99R76). 

@domoritz: I've added you as a reviewer to double check the type signatures, catch any errors, or make the signatures more precise. I haven't tested these typings beyond validating that VSCode did not report any errors for this file.

/cc @pelotom.