### PR TITLE
Fix identity typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export function field(field: string, name?: string): AccessorFn;
 
 export function id(_: object): symbol;
 
-export function identity<V>(v: V): () => V;
+export function identity<V>(v: V): V;
 
 export function key(fields: string[], flat?: boolean): (_: object) => string;
 


### PR DESCRIPTION
Identity simply returns the argument passed in (unlike constant, which returns a function that returns the argument value).